### PR TITLE
recognize *.gohtml

### DIFF
--- a/grammars/cshtml.cson
+++ b/grammars/cshtml.cson
@@ -1,7 +1,7 @@
 'name': 'ASP.NET Razor'
 'scopeName': 'text.html.cshtml'
 'fileTypes': [
-    'cshtml'
+    'cshtml', 'gohtml'
 ]
 'patterns': [
     {


### PR DESCRIPTION
I'm using the razor syntax in another context (https://github.com/sipin/gorazor), and it requires the use of a .gohtml extension, otherwise basically the same file type as the .cshtml