### PR TITLE
Fix quote handling

### DIFF
--- a/grammars/cshtml.json
+++ b/grammars/cshtml.json
@@ -109,13 +109,25 @@
         },
         "single-quotes": { "name": "string.quoted.single.cshtml",
           "begin": "'",
-          "end": "'"
+          "end": "'",
+          "patterns": [
+            {
+              "include": "text.html.basic"
+            },
+            {
+              "include": "#embedded-code"
+            }
         },
         "double-quotes": { "name": "string.quoted.double.cshtml",
           "begin": "\"",
           "end": "\"",
           "patterns": [
-            { "include": "text.html.basic" }
+            {
+              "include": "text.html.basic"
+            },
+            {
+              "include": "#embedded-code"
+            }
           ]
         },
         "round-brackets": { "name": "string.bracers.round.cshtml",


### PR DESCRIPTION
Single quotes no longer highlight to the end of file or next single quote in file
when that single quote is enclosed in tags.

Double quotes no longer highlight to the end of the line or next single quote when
that double quote is enclosed in tags.