### PR TITLE
Associate .cshtml files to language package

### DIFF
--- a/grammars/cshtml.json
+++ b/grammars/cshtml.json
@@ -1,6 +1,9 @@
 {
 	"name": "ASP.NET Razor",
 	"scopeName": "text.html.cshtml",
+	"fileTypes": [
+		"cshtml"
+	],
 	"patterns": [
         {
             "include": "#razor-directives"


### PR DESCRIPTION
The small change in this PR will associate `.cshtml` files with the syntax highlighting by this package automatically.